### PR TITLE
417 reorder table column

### DIFF
--- a/opus/application/apps/ui/templates/ui/base.html
+++ b/opus/application/apps/ui/templates/ui/base.html
@@ -288,7 +288,7 @@
             <div class="op-sort-list"></div>
         </div>
 
-        <div id="op-add-metadata-fields" class="dropdown-menu dropdown-menu-sm" data-toggle="dropdown" aria-labelledby="op-add-metadata-fields" aria-haspopup="true" aria-expanded="false">
+        <div id="op-add-metadata-fields" aria-labelledby="op-metadata-detail-add" class=" dropdown-menu dropdown-menu-sm">
             <h2 class="dropdown-header">Select Metadata Field</h2>
             <div class="op-select-list"></div>
         </div>

--- a/opus/application/static_media/js/browse.js
+++ b/opus/application/static_media/js/browse.js
@@ -344,6 +344,22 @@ var o_browse = {
             return false;
         });
 
+        // Toggle the submenu category and avoid dropdown menu #op-add-metadata-fields from closing
+        // When clicking inside #op-add-metadata-fields.
+        $(".app-body").on("click", "#op-add-metadata-fields", function(e) {
+            console.log("Click inside op-add-metadata-fields");
+            console.log(e.target);
+            if ($(e.target).hasClass("title")) {
+                e.stopPropagation();
+                let collapsibleID = $(e.target).parent().attr("href");
+                $(`${collapsibleID}`).collapse("toggle");
+            } else if ($(e.target).hasClass("op-submenu-category")) {
+                e.stopPropagation();
+                let collapsibleID = $(e.target).attr("href");
+                $(`${collapsibleID}`).collapse("toggle");
+            }
+        });
+
         $("#op-add-metadata-fields .op-select-list").on("click", '.submenu li a', function() {
             let slug = $(this).data('slug');
             if (!slug) { return; }
@@ -2241,7 +2257,7 @@ var o_browse = {
         let html = `<dl>`;
         let selectMetadataTitle = $(".op-metadata-modal").attr("title");
         let tools = `<li class="op-metadata-details-tools list-inline-item">` +
-                    `<a href="#" class="op-metadata-detail-add" title="${selectMetadataTitle}"><i class="fas fa-plus pr-1"></i></a>` +
+                    `<a href="#" class="op-metadata-detail-add" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false" title="${selectMetadataTitle}"><i class="fas fa-plus pr-1"></i></a>` +
                     `<a href="#" class="op-metadata-detail-remove" title="Remove selected metadata field"><i class="far fa-trash-alt"></i></a></li>`;
         $.each(opus.colLabels, function(index, columnLabel) {
             if (opusId === "" || viewNamespace.observationData[opusId] === undefined || viewNamespace.observationData[opusId][index] === undefined) {

--- a/opus/application/static_media/js/browse.js
+++ b/opus/application/static_media/js/browse.js
@@ -347,8 +347,6 @@ var o_browse = {
         // Toggle the submenu category and avoid dropdown menu #op-add-metadata-fields from closing
         // When clicking inside #op-add-metadata-fields.
         $(".app-body").on("click", "#op-add-metadata-fields", function(e) {
-            console.log("Click inside op-add-metadata-fields");
-            console.log(e.target);
             if ($(e.target).hasClass("title")) {
                 e.stopPropagation();
                 let collapsibleID = $(e.target).parent().attr("href");


### PR DESCRIPTION
- Move data-toggle, aria-haspopup and aria-expanded to .op-metadata-detail-add (the button that triggers the dropdown) a tag button. Separate these attributes from .dropdown-menu (#op-add-metadata-fields) to avoid the weird behavior that its sibling .container-fluid keeps toggling show class when any collapsible category inside #op-add-metadata-fields is clicked.
- After the above step, dropdown can be properly expanded and collapsed. However the menu will close after each click. This is the default behavior of bootstrap dropdown. Any item being clicked will automatically close the dropdown menu. Because we have multiple sub-category collapsible menus inside the big dropdown menu, we will need to manually prevent the event propagation when clicking on these sub-category name. 
- After above two steps, #op-add-metadata-fields dropdown menu will work. But we still need to highlight the clicked items.