### PR TITLE
Fixed the op-add-metadata-fields dropdown menu jumping issue

### DIFF
--- a/opus/application/static_media/js/browse.js
+++ b/opus/application/static_media/js/browse.js
@@ -349,6 +349,9 @@ var o_browse = {
         // When clicking inside #op-add-metadata-fields.
         $("#op-add-metadata-fields").on("click", ".op-submenu-category", function(e) {
             e.stopPropagation();
+            // Prevent dropdown menu from jumping when clicking on categories with scrollbar appears
+            // and disappears.
+            e.preventDefault();
             let collapsibleID = $(this).attr("href");
             $(`${collapsibleID}`).collapse("toggle");
         });


### PR DESCRIPTION
- Prevent dropdown menu from jumping when clicking on categories with scrollbar appears and disappears.