### PR TITLE
417 reorder table column

### DIFF
--- a/opus/application/apps/ui/templates/ui/base.html
+++ b/opus/application/apps/ui/templates/ui/base.html
@@ -311,7 +311,7 @@
                         <div class="row">
                             <div class="left col-lg-7 col-sm d-flex align-items-center justify-content-center op-no-select"></div>
                             <div class="right col-lg-5 col-sm">
-                                <div class="op-metatdata-detail-edit op-no-select">
+                                <div class="op-metadata-detail-edit op-no-select">
                                     <a href="#" class="op-edit-metadata-button" action="edit">
                                         <i class="fas fa-pencil-alt"></i> Edit
                                     </a>

--- a/opus/application/static_media/css/opus.css
+++ b/opus/application/static_media/css/opus.css
@@ -1109,6 +1109,7 @@ when window sized is narrow */
 /* to account for empty field data */
 #galleryViewContents .op-metadata-details .op-metadata-data {
     min-height: 1em;
+    overflow-wrap: anywhere;
 }
 
 /* prevent weird browser y-scrollbar */

--- a/opus/application/static_media/css/opus.css
+++ b/opus/application/static_media/css/opus.css
@@ -1109,6 +1109,8 @@ when window sized is narrow */
 /* to account for empty field data */
 #galleryViewContents .op-metadata-details .op-metadata-data {
     min-height: 1em;
+    /* Make sure info with long string like "Multiple Target List" is wrapped
+    in metadata detail modal */
     overflow-wrap: anywhere;
 }
 

--- a/opus/application/static_media/css/opus.css
+++ b/opus/application/static_media/css/opus.css
@@ -1112,6 +1112,8 @@ when window sized is narrow */
     /* Make sure info with long string like "Multiple Target List" is wrapped
     in metadata detail modal */
     overflow-wrap: anywhere;
+    /* For Safari */
+    line-break: anywhere;
 }
 
 /* prevent weird browser y-scrollbar */

--- a/opus/application/static_media/css/opus.css
+++ b/opus/application/static_media/css/opus.css
@@ -204,13 +204,13 @@ so that both "Recent Announcements" and "Message" can be vertically aligned. */
     background-color: transparent !important;
 }
 
-.op-metatdata-detail-edit {
+.op-metadata-detail-edit {
     margin-bottom: 0.5em;
     white-space: nowrap;
     display: inline-flex;
 }
 
-.op-metatdata-detail-edit a:hover {
+.op-metadata-detail-edit a:hover {
     text-decoration: none;
 }
 

--- a/opus/application/static_media/js/browse.js
+++ b/opus/application/static_media/js/browse.js
@@ -2128,6 +2128,8 @@ var o_browse = {
                     }
                 }
             }
+            // X-scrolling is not allowed in metadata detail modal.
+            o_browse.modalScrollbar.settings.suppressScrollX = true;
             o_browse.modalScrollbar.update();
         }
         $("#op-add-metadata-fields").removeData("last");

--- a/opus/application/static_media/js/browse.js
+++ b/opus/application/static_media/js/browse.js
@@ -2095,8 +2095,12 @@ var o_browse = {
     },
 
     adjustBrowseDialogPS: function() {
+        let modalHeight = $("#galleryViewContents").height();
+        let modalEditHeight = $(".op-metadata-detail-edit").outerHeight(true);
+        let bottomRowHeight = $("#galleryViewContents .bottom").outerHeight(true);
+        let calculatedContainerHeight = modalHeight - modalEditHeight - bottomRowHeight;
         let container = "#galleryViewContents .op-metadata-details";
-        let containerHeight = $(container).height();
+        let containerHeight = $(container).height(calculatedContainerHeight);
         let browseDialogHeight = $(`#galleryViewContents .op-metadata-details .contents`).height();
         let slug = $("#op-add-metadata-fields").data("slug");
         if (slug !== undefined) {


### PR DESCRIPTION
- Dynamically update the height of "#galleryViewContents .op-metadata-details" to make sure items in the right columns of metadata detail modal will not overlap with the bottom icon row.
- Change ".op-metatdata-detail-edit" to ".op-metadata-detail-edit".
- Add styling to make sure info with long string like "Multiple Target List" is wrapped in metadata detail modal.
