### PR TITLE
Update the placeholder height in the start event of jquery ui sortable

### DIFF
--- a/opus/application/static_media/js/browse.js
+++ b/opus/application/static_media/js/browse.js
@@ -2261,6 +2261,7 @@ var o_browse = {
                 o_browse.isSortingHappening = false;
             },
             start: function(e, ui) {
+                ui.placeholder.height(ui.helper.height());
                 o_widgets.getMaxScrollTopVal(e.target);
                 o_browse.isSortingHappening = true;
             },
@@ -2313,10 +2314,10 @@ var o_browse = {
                 let slug = opus.prefs.cols[index];
                 let style = (viewNamespace.metadataDetailEdit ? `style="opacity: 0.15"` : "");
                 let value = `<span class="op-detail-data" ${style}>${viewNamespace.observationData[opusId][index]}</span>`;
-                html += `<ul class="list-inline mb-0" data-slug="${slug}">${removeTool}`;
+                html += `<ul class="list-inline mb-2" data-slug="${slug}">${removeTool}`;
                 html += `<li class="op-metadata-detail-item">`;
                 html += `<div class="op-metadata-term font-weight-bold">${columnLabel}:</div>`;
-                html += `<div class="op-metadata-data mb-2 ml-0">${value}${addTool}</div>`;
+                html += `<div class="op-metadata-data ml-0">${value}${addTool}</div>`;
                 html += `</li></ul>`;
             }
         });


### PR DESCRIPTION
I can't find how jquery ui sortable determine its placeholder height when stort starts, but it's definitely not a fixed value since there is a forcePlaceholderSize option (https://api.jqueryui.com/sortable/#option-forcePlaceholderSize). So what I did was to make sure the height of placeholder (the item's future position) matches the height of helper (the currently grabbed item) when  sort starts. (there is a similar post here: https://stackoverflow.com/questions/6140680/jquery-sortable-placeholder-height-problem). That way there will be no extra row of space showing up in the placeholder when sort starts.

Also I think Debby you are right, the height is actually 42, but the extra 8 comes from the mb-2 of ".op-metadata-data". I move mb-2 to the parent ul, so that each sortable item is spaced by its owned mb-2 instead of the mb-2 of its children.