### PR TITLE
Update css styling to resize gallery view modal vertically.

### DIFF
--- a/opus/application/static_media/css/opus.css
+++ b/opus/application/static_media/css/opus.css
@@ -1127,9 +1127,21 @@ when window sized is narrow */
     flex-grow: 3;
 }
 
-/* prevent modal from shirnking to a too small window when resizing horizontally */
-#galleryView .left, #galleryView .right {
-    min-height: 75vh;
+#galleryView .left a, #galleryView .left a img {
+    height: 100%;
+}
+#galleryView .row {
+    height: 100%;
+}
+#op-gallery-view-contents {
+    height: 100%;
+}
+/* This is the place that restrict the size of the modal contents, now set it to 90% of window height by default */
+#galleryView .modal-dialog, #galleryView .modal-content {
+    height: 90%;
+}
+#galleryView {
+    height: 100%;
 }
 
 #op-gallery-view-contents .op-metadata-details {


### PR DESCRIPTION
- The content height of gallery modal is restricted by both left (image) and right (metadata details) columns of the contents, so it's line 1132 in opus.css ```min-height: 75vh;``` causing the problem.
- To make vertical resizing work for the modal, we need to do the followings:
    - Remove the height restrictions for .left & .right when resizing vertically (remove ```min-height: 75vh```)
    - Set every related div from parent to children to have height with percentage.

Two pending items:
- I don't know how to fix the location of modal when vertical resizing is happening.
- Need to set the min height for gallery view modal.
