### PR TITLE
Update the behavior for help submenu when clicking interpreting preview images

### DIFF
--- a/opus/application/static_media/js/opus.js
+++ b/opus/application/static_media/js/opus.js
@@ -835,8 +835,12 @@ var opus = {
 
         // Behavior for help submenu
         $("#op-help .dropdown-submenu .dropdown-item").on("click", function(e) {
-            $(this).next(".dropdown-menu").toggle("show");
             e.stopPropagation();
+            if($(this).hasClass("show")) {
+                $(this).next(".dropdown-menu").show();
+            } else {
+                $(this).next(".dropdown-menu").hide();
+            }
         });
 
         // Click on items inside submenu, we execute something and close the whole dropdown.


### PR DESCRIPTION
Bootstrap 5 dropdown behavior is a little different than Bootstrap 4. The dropdown-item under .dropstart ("Interpreting Preview Images" button) will have "show" class toggled too when it's clicked. And this will cause the weird behavior of the sub dropdown-menu (submenu opened when clicking "Interpreting Preview Images). The change here is to make sure whenever the "Interpreting Preview Images" has "show" class, we will show the submenu. And if the "show" class doesn't exist, we will close the submenu.