### PR TITLE
1190 bootstrap5 upgrade - Removed help menu when clicking on add column menu in browse table view

### DIFF
--- a/opus/application/apps/ui/templates/ui/base.html
+++ b/opus/application/apps/ui/templates/ui/base.html
@@ -262,7 +262,7 @@
                         </div>
                         <div class="op-edit-field-tool dropdown-menu border-top-0 border-dark mt-0" data-bs-toggle="dropdown" aria-labelledby="op-edit-field-tool" aria-haspopup="true" aria-expanded="false">
                             <div class="d-flex justify-content-between">
-                                <a href="#" class="op-metadata-detail-add op-base-tooltip" data-action="addBefore" title="Add a metadata field before this column"><i class="fas fa-plus ps-1"></i></a>
+                                <a href="#" class="op-metadata-detail-add op-base-tooltip" data-action="addBefore" title="Add a metadata field before this column" data-bs-toggle="dropdown"><i class="fas fa-plus ps-1"></i></a>
                                 <a href="#" class="op-metadata-detail-remove op-base-tooltip" data-action="remove" title="Remove this metadata field"><i class="far fa-trash-alt"></i></a>
                                 <a href="#" class="op-metadata-detail-add op-base-tooltip" data-action="addAfter" title="Add a metadata field after this column"><i class="fas fa-plus pe-1"></i></a>
                             </div>
@@ -307,7 +307,8 @@
         </div>
 
         <!-- dropdown menu for adding metadata fields -->
-        <div id="op-add-metadata-fields" class="op-no-select dropdown-menu" data-bs-toggle="dropdown" data-direction="after" aria-labelledby="op-add-metadata-fields" aria-haspopup="true" aria-expanded="false">
+        <div id="op-add-metadata-fields" class="op-no-select dropdown-menu" data-direction="after" aria-labelledby="op-metadata-detail-add" aria-haspopup="true" aria-expanded="false">
+        <!-- <div id="op-add-metadata-fields" class="op-no-select dropdown-menu" data-direction="after" aria-labelledby="op-add-metadata-fields" aria-haspopup="true" aria-expanded="false"> -->
             <h2 class="dropdown-header">Add Metadata Field</h2>
             <div class="op-select-list"></div>
         </div>

--- a/opus/application/apps/ui/templates/ui/base.html
+++ b/opus/application/apps/ui/templates/ui/base.html
@@ -308,7 +308,6 @@
 
         <!-- dropdown menu for adding metadata fields -->
         <div id="op-add-metadata-fields" class="op-no-select dropdown-menu" data-direction="after" aria-labelledby="op-metadata-detail-add" aria-haspopup="true" aria-expanded="false">
-        <!-- <div id="op-add-metadata-fields" class="op-no-select dropdown-menu" data-direction="after" aria-labelledby="op-add-metadata-fields" aria-haspopup="true" aria-expanded="false"> -->
             <h2 class="dropdown-header">Add Metadata Field</h2>
             <div class="op-select-list"></div>
         </div>


### PR DESCRIPTION
Bootstrap 5.2 required:
- The element triggering the dropdown menu to have ```data-bs-toggle="dropdown"```
- The menu to be open need to have ```aria-labelledby="the class name or id of the element triggering the dropdown menu"```
