### PR TITLE
Remove console error messages when clicking hamburger menu or items in the menu

### DIFF
--- a/opus/application/apps/ui/templates/ui/base.html
+++ b/opus/application/apps/ui/templates/ui/base.html
@@ -294,16 +294,16 @@
 
 
         <!-- dropdown menu for observations -->
-        <div id="op-obs-menu" class="dropdown-menu" data-bs-toggle="dropdown" aria-labelledby="op-obs-menu" aria-haspopup="true" aria-expanded="false">
-            <h2 class="dropdown-header" data-bs-toggle="dropdown"></h2>
-            <a class="dropdown-item" data-bs-toggle="dropdown" data-action="cart" href="#"><i class="fas fa-shopping-cart"></i>Add to cart</a>
-            <a class="dropdown-item" data-bs-toggle="dropdown" data-action="range" href="#"><i class="fas fa-step-backward"></i>Range selection</a>
-            <a class="dropdown-item" data-bs-toggle="dropdown" data-action="addall" href="#"><i class="fas fas fa-cart-plus"></i>Add all results to cart</a>
-            <a class="dropdown-item" data-bs-toggle="dropdown" data-action="info" href="#"><i class="fas fa-info-circle"></i>Show detail</a>
-            <a class="dropdown-item" data-bs-toggle="dropdown" data-action="downloadCSV" href="#" download><i class="fas fa-file-csv"></i>Download CSV of selected metadata&nbsp;</a>
-            <a class="dropdown-item" data-bs-toggle="dropdown" data-action="downloadCSVAll" href="#" download><i class="fas fa-file-csv"></i>Download CSV of all metadata&nbsp;</a>
-            <a class="dropdown-item" data-bs-toggle="dropdown" data-action="downloadData" href="#" download><i class="fas fa-download"></i>Download zipped data archive&nbsp;</a>
-            <a class="dropdown-item" data-bs-toggle="dropdown" data-action="downloadURL" href="#" download><i class="fas fa-download"></i>Download zipped URL archive&nbsp;</a>
+        <div id="op-obs-menu" class="dropdown-menu" aria-labelledby="op-obs-menu" aria-haspopup="true" aria-expanded="false">
+            <h2 class="dropdown-header"></h2>
+            <a class="dropdown-item" data-action="cart" href="#"><i class="fas fa-shopping-cart"></i>Add to cart</a>
+            <a class="dropdown-item" data-action="range" href="#"><i class="fas fa-step-backward"></i>Range selection</a>
+            <a class="dropdown-item" data-action="addall" href="#"><i class="fas fas fa-cart-plus"></i>Add all results to cart</a>
+            <a class="dropdown-item" data-action="info" href="#"><i class="fas fa-info-circle"></i>Show detail</a>
+            <a class="dropdown-item" data-action="downloadCSV" href="#" download><i class="fas fa-file-csv"></i>Download CSV of selected metadata&nbsp;</a>
+            <a class="dropdown-item" data-action="downloadCSVAll" href="#" download><i class="fas fa-file-csv"></i>Download CSV of all metadata&nbsp;</a>
+            <a class="dropdown-item" data-action="downloadData" href="#" download><i class="fas fa-download"></i>Download zipped data archive&nbsp;</a>
+            <a class="dropdown-item" data-action="downloadURL" href="#" download><i class="fas fa-download"></i>Download zipped URL archive&nbsp;</a>
         </div>
 
         <!-- dropdown menu for adding metadata fields -->

--- a/opus/application/static_media/js/browse.js
+++ b/opus/application/static_media/js/browse.js
@@ -2991,7 +2991,7 @@ var o_browse = {
             html += `</div>`;
 
             // mini-menu like the hamburger on the observation/gallery page
-            html += `<div class="col text-start"><a href="#" class="menu pe-3 float-end text-center op-metadatabox-tooltip" data-bs-toggle="dropdown" role="button" data-id="${opusId}" title="More options"><i class="fas fa-bars fa-2x"></i></a></div>`;
+            html += `<div class="col text-start"><a href="#" class="menu pe-3 float-end text-center op-metadatabox-tooltip" role="button" data-id="${opusId}" title="More options"><i class="fas fa-bars fa-2x"></i></a></div>`;
             $(".op-metadata-detail-view-body .bottom").html(html);
 
             // update the binoculars here


### PR DESCRIPTION
Remove ```data-bs-toggle="dropdown"``` from .op-metadatabox-tooltip & #op-obs-menu and its dropdown-item.